### PR TITLE
256_select_a_form

### DIFF
--- a/backoffice/src/commons/JotformButton.js
+++ b/backoffice/src/commons/JotformButton.js
@@ -18,6 +18,7 @@ const JotformButton = (props) => {
   }, [clicked]);
 
   const record = useRecordContext(props);
+  const link = record[props.source];
 
   const id = record.id;
   const startDate = record["pair:startDate"]
@@ -61,13 +62,13 @@ const JotformButton = (props) => {
                 typeVoyage: types.map((t) => t["pair:label"]).join(", "),
               },
               { label },
-              { LEPId: id },
+              { lepid: id },
               priceRange && { prix: priceRange.replace(/[^0-9]/g, "") }
             )
           );
 
           navigator.clipboard.writeText(
-            "https://form.jotform.com/212722469132048?" + query
+            link + query
           );
         }}
         disabled={clicked}

--- a/backoffice/src/pair/index.js
+++ b/backoffice/src/pair/index.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ReferenceArrayInput, ReferenceInput } from '@semapps/semantic-data-provider';
-import { AutocompleteInput, AutocompleteArrayInput, SelectInput } from 'react-admin';
+import { AutocompleteInput, AutocompleteArrayInput, SelectInput, BooleanInput, TextInput } from 'react-admin';
+import { FormDataConsumer } from 'react-admin';
 
 export const OrganizationsInput = ({ label, source }) => (
   <ReferenceArrayInput label={label} reference="Organization" source={source}>
@@ -127,6 +128,31 @@ export const PathInput = ({ label, source, ...rest }) => (
     <SelectInput optionText="pair:label" allowEmpty />
   </ReferenceInput>
 );
+
+const options = [
+  { id: "https://form.jotform.com/212722469132048?", name: 'Formulaire événement' },
+  { id: "https://form.jotform.com/212722469132048?", name: 'Formulaire voyage' },
+  { id: "https://form.jotform.com/212722469132048?", name: 'Formulaire chemin' },
+  { id: "https://form.jotform.com/212722469132048?", name: 'Formulaire lieu' },
+]
+
+export const JotFormInput = ({ label, source, booleanSource, booleanLabel, ...rest }) => (
+  <>
+    <FormDataConsumer {...rest}>
+        {({ formData, ...rest }) => formData[booleanSource] ?
+          <TextInput label={label} source={source} {...rest} type="url"/>
+        :
+          <SelectInput 
+            source={source}
+            choices={options} 
+            {...rest}
+            allowEmpty
+          />
+      }
+    </FormDataConsumer>
+    <BooleanInput label={booleanLabel} source={booleanSource} />
+  </>
+)
 
 export { default as PairLocationInput } from './PairLocationInput';
 export { default as PairResourceCreate } from './PairResourceCreate';

--- a/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
@@ -13,7 +13,8 @@ import {
   StatusInput,
   TypesInput,
   SkillsInput,
-  DocumentsType
+  DocumentsType,
+  JotFormInput
 } from '../../../../pair';
 import CourseTitle from './CourseTitle';
 import { DateInput } from '@semapps/date-components';
@@ -70,6 +71,13 @@ const CourseEdit = (props) => (
         <PersonsInput source="cdlt:hasMentor" />
         <DocumentsType source="pair:documentedBy" />
         <FinalitiesInput source="pair:hasFinality" />
+        <JotFormInput 
+          label="Lien personnalisé du formulaire d'inscription" 
+          source="cdlt:jotformLink" 
+          booleanSource="cdlt:personalizedJotformLink" 
+          booleanLabel="Utiliser un lien personnalisé" 
+          fullWidth
+        />
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth />

--- a/backoffice/src/resources/Agent/Activity/Course/CourseShow.js
+++ b/backoffice/src/resources/Agent/Activity/Course/CourseShow.js
@@ -45,7 +45,7 @@ const CourseShow = (props) => (
           </ReferenceField>
           <BooleanField addLabel source="cdlt:directRegistration" />
         </Hero>
-        <JotformButton />
+        <JotformButton source="cdlt:jotformLink"/>
         <MainList>
           <MarkdownField source="pair:description" />
           <MarkdownField source="cdlt:organizerDescription" />

--- a/backoffice/src/resources/Agent/Activity/Course/index.js
+++ b/backoffice/src/resources/Agent/Activity/Course/index.js
@@ -53,6 +53,8 @@ export default {
         'pair:documentedBy': 'Documents',
         'cdlt:courseOn': 'Est un voyage de',
         'pair:hasFinality': 'Finalités',
+        'cdlt:jotformLink':"Formulaire d'inscription",
+        'cdlt:personalizedJotformLink':"Utiliser un lien personnalisé",
       },
     },
   },

--- a/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
@@ -5,7 +5,7 @@ import { MarkdownInput } from '@semapps/markdown-components';
 import { EditWithPermissions } from '@semapps/auth-provider';
 import { DateTimeInput } from '@semapps/date-components';
 import { ImageField } from '@semapps/semantic-data-provider';
-import { PairLocationInput, ActorsInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput } from '../../../../pair';
+import { PairLocationInput, ActorsInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput, JotFormInput } from '../../../../pair';
 import EventTitle from './EventTitle';
 
 const EventEdit = (props) => (
@@ -64,6 +64,11 @@ const EventEdit = (props) => (
         <TypeInput source="pair:hasType" filter={{ a: 'pair:EventType' }} validate={[required()]} />
         <SkillsInput source="pair:produces" fullWidth />
         <FinalitiesInput source="pair:hasFinality" />
+        <JotFormInput 
+          label="Lien personnalisé du formulaire d'inscription" 
+          source="cdlt:jotformLink" 
+          booleanSource="cdlt:personalizedJotformLink" 
+          booleanLabel="Utiliser un lien personnalisé" fullWidth/>
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth validate={[required(), email()]} />

--- a/backoffice/src/resources/Agent/Activity/Event/EventShow.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventShow.js
@@ -43,7 +43,7 @@ const EventShow = (props) => (
           <UrlField source="pair:aboutPage" />
           <BooleanField addLabel source="cdlt:directRegistration" />
         </Hero>
-        <JotformButton />
+        <JotformButton source="cdlt:jotformLink"/>
         <MainList>
           <MarkdownField source="pair:description" />
           <MarkdownField source="cdlt:organizerDescription" />

--- a/backoffice/src/resources/Agent/Activity/Event/index.js
+++ b/backoffice/src/resources/Agent/Activity/Event/index.js
@@ -58,6 +58,8 @@ export default {
         'cdlt:hasMentor': 'Intervenant(e)s',
         'cdlt:eventOn': 'Est un événement de',
         'pair:hasFinality': 'Finalités',
+        'cdlt:jotformLink':"Formulaire d'inscription",
+        'cdlt:personalizedJotformLink':"Utiliser un lien personnalisé",
       },
     },
   },

--- a/backoffice/src/resources/Idea/Path/PathEdit.js
+++ b/backoffice/src/resources/Idea/Path/PathEdit.js
@@ -15,6 +15,7 @@ import {
   ThemesInput,
   // TypesInput,
   SkillsInput,
+  JotFormInput,
 } from '../../../pair';
 import PathTitle from './PathTitle';
 
@@ -52,6 +53,13 @@ const PathEdit = (props) => (
         <SkillsInput source="pair:produces" />
         <ThemesInput source="pair:hasTopic" />
         <FinalitiesInput source="pair:hasFinality" />
+        <JotFormInput 
+          label="Lien personnalisé du formulaire d'inscription" 
+          source="cdlt:jotformLink" 
+          booleanSource="cdlt:personalizedJotformLink" 
+          booleanLabel="Utiliser un lien personnalisé" 
+          fullWidth
+        />
       </FormTab>
     </TabbedForm>
   </EditWithPermissions>

--- a/backoffice/src/resources/Idea/Path/PathShow.js
+++ b/backoffice/src/resources/Idea/Path/PathShow.js
@@ -7,6 +7,7 @@ import { ReferenceArrayField } from '@semapps/semantic-data-provider';
 import { MarkdownField } from '@semapps/markdown-components';
 import { MapList } from '@semapps/geo-components';
 import PathTitle from './PathTitle';
+import JotformButton from '../../../commons/JotformButton';
 
 const PathShow = (props) => (
   <ShowWithPermissions title={<PathTitle />} {...props}>
@@ -25,6 +26,7 @@ const PathShow = (props) => (
           </ReferenceField>
           */}
         </Hero>
+        <JotformButton source="cdlt:jotformLink"/>
         <MainList>
           <MarkdownField source="pair:description" />
           {/*

--- a/backoffice/src/resources/Idea/Path/index.js
+++ b/backoffice/src/resources/Idea/Path/index.js
@@ -38,6 +38,8 @@ export default {
         'cdlt:hasCourse': 'Voyages', /*Course*/
         'pair:hasTopic': 'A pour secteur d\'activité',
         'pair:hasFinality': 'Finalités',
+        'cdlt:jotformLink':"Formulaire d'inscription",
+        'cdlt:personalizedJotformLink':"Utiliser un lien personnalisé",
         /*
         'pair:hasLocation': 'Composez votre voyage',
         'pair:hasStatus': 'Statut',

--- a/backoffice/src/resources/Place/PlaceEdit.js
+++ b/backoffice/src/resources/Place/PlaceEdit.js
@@ -5,7 +5,7 @@ import { extractContext, LocationInput } from '@semapps/geo-components';
 import { EditWithPermissions } from '@semapps/auth-provider';
 import { ImageField } from '@semapps/semantic-data-provider';
 import PlaceTitle from './PlaceTitle';
-import { FinalitiesInput, PathsInput, ThemesInput, TypeInput, TypesInput, SkillsInput, PersonsInput, StatusInput } from '../../pair';
+import { FinalitiesInput, PathsInput, ThemesInput, TypeInput, TypesInput, SkillsInput, PersonsInput, StatusInput, JotFormInput } from '../../pair';
 
 export const PlaceEdit = (props) => (
   <EditWithPermissions title={<PlaceTitle />} {...props}>
@@ -53,6 +53,13 @@ export const PlaceEdit = (props) => (
         {/*<EventsInput source="pair:hosts" fullWidth />*/}
         <SkillsInput source="pair:produces" fullWidth />
         <FinalitiesInput source="pair:hasFinality" />
+        <JotFormInput 
+          label="Lien personnalisé du formulaire d'inscription" 
+          source="cdlt:jotformLink" 
+          booleanSource="cdlt:personalizedJotformLink" 
+          booleanLabel="Utiliser un lien personnalisé" 
+          fullWidth
+        />
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth />

--- a/backoffice/src/resources/Place/PlaceShow.js
+++ b/backoffice/src/resources/Place/PlaceShow.js
@@ -38,7 +38,7 @@ const PlaceShow = (props) => (
           <UrlField source="pair:homePage" />
           <BooleanField addLabel source="cdlt:directRegistration" />
         </Hero>
-        <JotformButton />
+        <JotformButton source="cdlt:jotformLink"/>
         <MainList>
           <MarkdownField source="pair:description" addLabel />
           <MarkdownField source="cdlt:hostDescription" addLabel />

--- a/backoffice/src/resources/Place/index.js
+++ b/backoffice/src/resources/Place/index.js
@@ -58,6 +58,8 @@ export default {
         'pair:homePage': 'Site web',
         'cdlt:placeOn': 'Est un lieu de',
         'pair:hasFinality': 'Finalités',
+        'cdlt:jotformLink':"Formulaire d'inscription",
+        'cdlt:personalizedJotformLink':"Utiliser un lien personnalisé",
       },
     },
   },

--- a/frontoffice/src/commons/buttons/ContactButton.js
+++ b/frontoffice/src/commons/buttons/ContactButton.js
@@ -6,7 +6,6 @@ import JotformButton from "./JotformButton";
 
 const ContactButton = ({ label }) => {
   const [showDialog, setShowDialog] = useState(false);
-  // const record = useRecordContext();
   const { record = {} } = useShowContext();
 
   if (record["cdlt:directRegistration"]) {

--- a/frontoffice/src/commons/buttons/JotformButton.js
+++ b/frontoffice/src/commons/buttons/JotformButton.js
@@ -9,7 +9,7 @@ const JotformButton = ({ label: labelProp }) => {
 
   const { record = {} } = useShowContext();
 
-  console.log("record", record);
+  const link = record['cdlt:jotformLink'] ? record['cdlt:jotformLink'] : "https://form.jotform.com/212722469132048?";
 
   const id = record.id;
   const startDate = record["pair:startDate"]
@@ -22,11 +22,7 @@ const JotformButton = ({ label: labelProp }) => {
   const label = record["pair:label"];
   const hasType = record["pair:hasType"];
 
-  console.log(priceRange);
-
   useEffect(() => {
-    console.log("=>", hasType);
-
     if (!hasType) return;
     const promisesArray = Array.isArray(hasType) ? hasType : [hasType];
     Promise.all(
@@ -38,10 +34,8 @@ const JotformButton = ({ label: labelProp }) => {
 
   if (record.hasType && !types) return null;
 
-  console.log("types", types);
-
   const href =
-    "https://form.jotform.com/212722469132048?" +
+    link +
     qs.stringify(
       Object.assign(
         {},
@@ -59,7 +53,7 @@ const JotformButton = ({ label: labelProp }) => {
           typeVoyage: types.map((t) => t["pair:label"]).join(", "),
         },
         { label },
-        { LEPId: id },
+        { lepid: id },
         priceRange && { prix: priceRange.replace(/[^0-9]/g, "") }
       )
     );


### PR DESCRIPTION
@GuillaumeAV
J'ai ajouté la possibilité de sélectionner un formulaire ou d'ajouter son propre lien : 
![choose_jotform2](https://user-images.githubusercontent.com/99750303/170249443-1141bb17-db2c-4e7e-8157-9a7d07e8494d.png)
![choose_jotform](https://user-images.githubusercontent.com/99750303/170249449-e9673c18-0687-423c-a4d4-a3213b86c173.png)

Pour l'instant j'ai mis le même lien pour les 4 formulaires, une fois créés il faudra les modifier. J'ai également laissé par défaut le lien du formulaire initial si le champs n'est pas renseigné. Je rajouterai également les 2 nouveaux champs dans l'ontologie.