### PR TITLE
327_add_referent_person

### DIFF
--- a/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
@@ -5,7 +5,7 @@ import { EditWithPermissions } from '@semapps/auth-provider';
 import { ImageField } from '@semapps/semantic-data-provider';
 import {
   PathsInput, 
-  ActorsInput,
+  OrganizationsInput,
   FinalitiesInput,
   PersonsInput,
   /*EventsInput,*/
@@ -73,7 +73,8 @@ const CourseEdit = (props) => (
         <ThemesInput source="pair:hasTopic" />
         {/*<EventsInput source="pair:hasPart" />*/}
         <SkillsInput source="pair:produces" />
-        <ActorsInput source="cdlt:organizedBy" />
+        <OrganizationsInput source="cdlt:organizedBy" />
+        <PersonsInput source="cdlt:hasReferent" />
         <PersonsInput source="cdlt:hasMentor" />
         <DocumentsType source="pair:documentedBy" />
         <FinalitiesInput source="pair:hasFinality" />

--- a/backoffice/src/resources/Agent/Activity/Course/CourseShow.js
+++ b/backoffice/src/resources/Agent/Activity/Course/CourseShow.js
@@ -106,7 +106,14 @@ const CourseShow = (props) => (
       </Grid>
       <Grid item xs={12} sm={3}>
         <SideList>
-          <ReferenceArrayField reference="Actor" source="cdlt:organizedBy">
+          <ReferenceArrayField reference="Organization" source="cdlt:organizedBy">
+            <GridList xs={6} linkType="show">
+              <AvatarField label="pair:label" image="pair:depictedBy" labelColor="grey.300">
+                <HomeIcon />
+              </AvatarField>
+            </GridList>
+          </ReferenceArrayField>
+          <ReferenceArrayField reference="Person" source="cdlt:hasReferent">
             <GridList xs={6} linkType="show">
               <AvatarField label="pair:label" image="pair:depictedBy" labelColor="grey.300">
                 <HomeIcon />

--- a/backoffice/src/resources/Agent/Activity/Course/index.js
+++ b/backoffice/src/resources/Agent/Activity/Course/index.js
@@ -49,6 +49,7 @@ export default {
         'pair:comment': "Phrase d'accroche",
         'cdlt:hasMentor': 'A pour intervenant',
         'cdlt:organizedBy': 'Organisé par',
+        'cdlt:hasReferent':'Personne référente',
         'pair:hasStatus': 'Statut',
         'pair:documentedBy': 'Documents',
         'cdlt:courseOn': 'Est un voyage de',

--- a/backoffice/src/resources/Agent/Activity/Event/EventCreate.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventCreate.js
@@ -76,7 +76,7 @@ const EventCreate = (props) => {
     for (const property in chosenEvent) {
       if (! ['id','dc','type'].includes(property.split(':')[0])) {
         if ( ! [
-          'cdlt:organizedBy',
+          'cdlt:hasReferent',
           'pair:label',
         ].includes(property)) {
           formatedEvent = { ...formatedEvent, [property]: chosenEvent[property] };
@@ -84,7 +84,7 @@ const EventCreate = (props) => {
       }
     }
     if (identity?.id) {
-      formatedEvent = { ...formatedEvent, 'cdlt:organizedBy': identity?.id };
+      formatedEvent = { ...formatedEvent, 'cdlt:hasReferent': identity?.id };
     }
     return { ...formatedEvent, 'cdlt:referenceNumber':generateReference()}
   }, []);

--- a/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
@@ -5,7 +5,7 @@ import { MarkdownInput } from '@semapps/markdown-components';
 import { EditWithPermissions } from '@semapps/auth-provider';
 import { DateTimeInput } from '@semapps/date-components';
 import { ImageField } from '@semapps/semantic-data-provider';
-import { PairLocationInput, ActorsInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput, RegistrationInput } from '../../../../pair';
+import { PairLocationInput, OrganizationsInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput, RegistrationInput } from '../../../../pair';
 import EventTitle from './EventTitle';
 
 const EventEdit = (props) => (
@@ -75,7 +75,8 @@ const EventEdit = (props) => (
       </FormTab>
 
       <FormTab label="Relations">
-        <ActorsInput source="cdlt:organizedBy" />
+        <OrganizationsInput source="cdlt:organizedBy" />
+        <PersonsInput source="cdlt:hasReferent" />
         <PersonsInput source="cdlt:hasMentor" />
         <PlaceInput source="pair:hostedIn" />
         <CourseInput source="pair:partOf" />

--- a/backoffice/src/resources/Agent/Activity/Event/EventShow.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventShow.js
@@ -79,7 +79,12 @@ const EventShow = (props) => (
       </Grid>
       <Grid item xs={12} sm={3}>
         <SideList>
-          <ReferenceArrayField reference="Actor" source="cdlt:organizedBy">
+          <ReferenceArrayField reference="Organization" source="cdlt:organizedBy">
+            <GridList xs={6} linkType="show">
+              <AvatarField label="pair:label" image="pair:depictedBy" labelColor="grey.300" />
+            </GridList>
+          </ReferenceArrayField>
+          <ReferenceArrayField reference="Person" source="cdlt:hasReferent">
             <GridList xs={6} linkType="show">
               <AvatarField label="pair:label" image="pair:depictedBy" labelColor="grey.300" />
             </GridList>

--- a/backoffice/src/resources/Agent/Activity/Event/index.js
+++ b/backoffice/src/resources/Agent/Activity/Event/index.js
@@ -72,6 +72,7 @@ export default {
         'cdlt:jotformLink':"Formulaire d'inscription JotForm",
         'cdlt:registrationLink':"Lien du système d'inscription",
         'cdlt:referenceNumber':"Numéro de référence",
+        'cdlt:hasReferent':'Personne référente',
       },
     },
   },

--- a/frontoffice/src/pages/MyEventsPage.js
+++ b/frontoffice/src/pages/MyEventsPage.js
@@ -18,7 +18,7 @@ const MyEventsPage = () => {
       <br />
       <FullWidthBox>
         <LargeContainer>
-          <ListBase resource="Event" basePath="/Event" filter={{ 'cdlt:organizedBy': identity?.id }}>
+          <ListBase resource="Event" basePath="/Event" filter={{ 'cdlt:hasReferent': identity?.id }}>
             <CardsList CardComponent={EventCard} link="show" />
           </ListBase>
         </LargeContainer>

--- a/frontoffice/src/resources/Activity/Course/index.js
+++ b/frontoffice/src/resources/Activity/Course/index.js
@@ -48,6 +48,7 @@ export default {
         'pair:comment': "Phrase d'accroche",
         'cdlt:hasMentor': 'A pour intervenant',
         'cdlt:organizedBy': 'Organisé par',
+        'cdlt:hasReferent': 'Personne référente',
         'pair:hasStatus': 'Statut',
         'cdlt:courseOn': 'Chemins',
         'pair:hasFinality': 'Finalités',

--- a/frontoffice/src/resources/Activity/Event/EventDetails.js
+++ b/frontoffice/src/resources/Activity/Event/EventDetails.js
@@ -57,7 +57,12 @@ const EventDetails = (props) => (
       endDate="pair:endDate"
       icon={<DurationIcon />}
     />
-    <ReferenceArrayField reference="Actor" source="cdlt:organizedBy" perPage={2} icon={<ActorIcon/>} link="show" sort={{ field: 'type', order: 'DESC' }} >
+    <ReferenceArrayField reference="Organization" source="cdlt:organizedBy" perPage={2} icon={<ActorIcon/>} link="show" sort={{ field: 'type', order: 'DESC' }} >
+      <SeparatedListField link="show" separator=" / ">
+        <TextField source="pair:label" />
+      </SeparatedListField>
+    </ReferenceArrayField>
+    <ReferenceArrayField reference="Person" source="cdlt:hasReferent" perPage={2} icon={<ActorIcon/>} link="show" sort={{ field: 'type', order: 'DESC' }} >
       <SeparatedListField link="show" separator=" / ">
         <TextField source="pair:label" />
       </SeparatedListField>

--- a/frontoffice/src/resources/Activity/Event/EventForm.js
+++ b/frontoffice/src/resources/Activity/Event/EventForm.js
@@ -15,7 +15,7 @@ import {
 import { MarkdownInput } from '@semapps/markdown-components';
 import { ImageField } from '@semapps/semantic-data-provider';
 import { DateTimeInput } from '@semapps/date-components';
-import { PairLocationInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput, ActorsInput, RegistrationInput } from '../../../pair';
+import { PairLocationInput, FinalitiesInput, PathsInput, PersonsInput, PlaceInput, SkillsInput, ThemesInput, TypeInput, CourseInput, OrganizationsInput, RegistrationInput } from '../../../pair';
 import frLocale from 'date-fns/locale/fr';
 import { Box, FormControlLabel, Slide, LinearProgress, makeStyles, Switch } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
@@ -87,20 +87,20 @@ const EventForm = ({ mode, ...rest }) => {
     for (const property in chosenEvent) {
       if (! ['id','dc','type'].includes(property.split(':')[0])) {
         if ( ! [
-          'cdlt:organizedBy',
+          'cdlt:hasReferent',
           'pair:label',
         ].includes(property)) {
           formatedEvent = { ...formatedEvent, [property]: chosenEvent[property] };
         }
       }
     }
-    return { ...formatedEvent, 'cdlt:referenceNumber':generateReference(), 'cdlt:organizedBy': identity?.id }
+    return { ...formatedEvent, 'cdlt:referenceNumber':generateReference(), 'cdlt:hasReferent': identity?.id }
   }, [identity]);
 
   const initalValues = (mode) => {
     switch (mode) {
       case 'create': return {
-        'cdlt:organizedBy': identity?.id,
+        'cdlt:hasReferent': identity?.id,
         /* force components to be controlled : needed for duplication feature */
         'cdlt:hasMentor': null,
         'pair:hostedIn': null,
@@ -223,7 +223,8 @@ const EventForm = ({ mode, ...rest }) => {
         />
       </FormTab>
       <FormTab label="Relations">
-        <ActorsInput source="cdlt:organizedBy"/>
+        <OrganizationsInput source="cdlt:organizedBy"/>
+        <PersonsInput source="cdlt:hasReferent"/>
         <PersonsInput source="cdlt:hasMentor" />
         <PlaceInput source="pair:hostedIn" />
         <CourseInput source="pair:partOf" />

--- a/frontoffice/src/resources/Activity/Event/index.js
+++ b/frontoffice/src/resources/Activity/Event/index.js
@@ -54,6 +54,7 @@ export default {
         'pair:phone': 'Téléphone',
         'pair:aboutPage': 'Site web',
         'cdlt:organizedBy': 'Organisé par',
+        'cdlt:hasReferent': 'Personne référente',
         'cdlt:hasMentor': 'Intervenant(e)s',
         'cdlt:eventOn': 'Chemins',
         'pair:hasFinality': 'Finalités',

--- a/middleware/services/authorizer.service.js
+++ b/middleware/services/authorizer.service.js
@@ -10,7 +10,7 @@ module.exports = {
           read: true,
           write: true
         },
-        users: record => record['cdlt:organizedBy']
+        users: record => record['cdlt:hasReferent']
       },
       {
         match: { type: 'pair:Place' },


### PR DESCRIPTION
Nécessite sûrement une migration de données car "organizedBy" était utilisé pour récupérer les événements et voyages organisés par les personnes (maintenant séparé en organizedBy pour les orgas et hasReferent pour les personnes)