### PR TITLE
Allow scrolling for events in homepage in mobile view

### DIFF
--- a/frontoffice/src/commons/lists/EventsList/NextEvents.js
+++ b/frontoffice/src/commons/lists/EventsList/NextEvents.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react' ;
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, Box } from '@material-ui/core';
 import { ListBase } from 'react-admin';
 import EventItemsGrid from './EventItemsGrid';
 import AgendaFilter from './AgendaFilter';
@@ -11,6 +11,9 @@ const useStyles = makeStyles((theme) => ({
     color: theme.palette.primary.contrastText,
     marginBottom: 40
   },
+  eventsBox: {
+    overflow: 'scroll',
+  }
 }));
 
 const NextEvents = () => {
@@ -35,6 +38,7 @@ const NextEvents = () => {
         region={region}
         setRegion={setRegion}
       />
+      <Box className={classes.eventsBox}>
       <ListBase
         resource="Event"
         basePath="/Event"
@@ -46,6 +50,7 @@ const NextEvents = () => {
       >
         <EventItemsGrid />
       </ListBase>
+      </Box>
     </>
   );
 };

--- a/frontoffice/src/commons/lists/FeaturedList/FeaturedList.js
+++ b/frontoffice/src/commons/lists/FeaturedList/FeaturedList.js
@@ -104,7 +104,7 @@ const FeaturedList = ({ resource, basePath, title, subtitle, logo, linkText, Car
           </Link>
         </Box>
         {isAgenda ? 
-          <Box className={classes.listBase}>
+          <Box>
             <NextEvents />
           </Box>
         : 


### PR DESCRIPTION
commentaire Mathieu :
Agenda des événements : 
Mettre un slideware avec davantage d’événements (possibilité de navigation horizontale à travers les événements depuis la HP)
