### PR TITLE
243_gestion_photos

### DIFF
--- a/frontoffice/src/commons/HeaderShow.js
+++ b/frontoffice/src/commons/HeaderShow.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import {
   makeStyles,
   Typography,
@@ -61,7 +61,6 @@ resourceLink: {
   images: {
     marginBottom: 15,
     '& img': {
-      width: '100%',
       display: 'block',
       borderRadius: 8,
       backgroundSize: 'cover',
@@ -71,10 +70,15 @@ resourceLink: {
       margin: '5px 0 10px 0',
       height: '100%',
       maxHeight: '15rem',
-      [theme.breakpoints.down('xs')]: {
-        maxHeight: '8rem',
-      }
+      maxWidth: "-webkit-fill-available",
     },
+  },
+  fullWidth: {
+    width: '100%'
+  },
+  leftImage: {
+    float: 'left',
+    margin: '5px 10px 20px 0 !important',
   },
   drawer: {
     backgroundColor: theme.palette.primary.main,
@@ -90,22 +94,29 @@ resourceLink: {
 }));
 
 const MultipleImagesField = ({ source, max = 2 }) => {
+  const classes = useStyles();
   const record = useRecordContext();
-  if( !record ) return null;
+  const [imageWidth, setImageWidth] = useState(0);
 
+  const onImgLoad = ({ target: img }) => {
+    const { offsetWidth } = img;
+    setImageWidth(offsetWidth);
+  };
+
+  if( !record ) return null;
   if( Array.isArray(record[source]) ) {
     return(
       <Grid container spacing={2}>
         {record[source].slice(0,max).map((url, i) => (
-          <Grid item xs={6} key={i}>
-            <img src={url} alt={record['pair:label']} />
+          <Grid item xs={6} key={i} >
+            <img src={url} className={classes.fullWidth} alt={record['pair:label']} />
           </Grid>
         ))}
       </Grid>
     )
   } else {
     return(
-      <img src={record[source]} alt={record['pair:label']} />
+      <img src={record[source]} onLoad={onImgLoad} className={(imageWidth > 1000) ? classes.fullWidth : (imageWidth < 400) ? classes.leftImage :''} alt={record['pair:label']} />
     )
   }
 };


### PR DESCRIPTION
@Mathieu-CdlT 
J'ai adapté l'affichage en fonction de la photo : 
* Si elle est large ou qu'il y en a plusieurs, on l'affiche en bandeau : 

![image_bandeau](https://user-images.githubusercontent.com/99750303/176180505-cbe51980-aaf0-4a41-ac2a-eadc20597f4d.png)
![double_image](https://user-images.githubusercontent.com/99750303/176180509-be282114-11cf-4878-9250-055c528b337e.png)

Si elle est assez petite, on l'affiche sur la gauche : 

![image_coté_personne](https://user-images.githubusercontent.com/99750303/176180503-9dcb7692-8862-4e11-9ef7-4c85f6a2fe5e.png)
![image_coté](https://user-images.githubusercontent.com/99750303/176180498-792fb5dc-4b9d-40c1-bc22-4eed2ec5dbff.png)

Et entre les deux on l'affiche en haut mais pas zoomée : 

![image_dessus](https://user-images.githubusercontent.com/99750303/176180493-2d9701ae-f705-4891-87f1-2a3f54cbe7eb.png)
