### PR TITLE
350_reorganize_fields

### DIFF
--- a/backoffice/src/pair/index.js
+++ b/backoffice/src/pair/index.js
@@ -3,68 +3,68 @@ import { ReferenceArrayInput, ReferenceInput } from '@semapps/semantic-data-prov
 import { AutocompleteInput, AutocompleteArrayInput, SelectInput } from 'react-admin';
 import { LexiconCreateDialog, fetchESCO, fetchWikidata } from "@semapps/interop-components";
 
-export const OrganizationsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Organization" source={source}>
+export const OrganizationsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Organization" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const ActorsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Actor" source={source}>
+export const ActorsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Actor" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const PersonsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Person" source={source}>
+export const PersonsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Person" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const ActivitiesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Activity" source={source}>
+export const ActivitiesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Activity" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const EventsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Event" source={source}>
+export const EventsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Event" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const PlacesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Place" source={source}>
+export const PlacesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Place" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const DocumentsType = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Document" source={source}>
+export const DocumentsType = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Document" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const PathsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Path" source={source}>
+export const PathsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Path" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
   
-export const FinalitiesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Finality" source={source}>
+export const FinalitiesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Finality" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const SectorsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Sector" source={source}>
+export const SectorsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Sector" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const SkillsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Skill" source={source}>
+export const SkillsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Skill" source={source} {...rest}>
     <AutocompleteArrayInput
       optionText="pair:label"
       shouldRenderSuggestions={(value) => value.length > 1}
@@ -82,8 +82,8 @@ export const SkillsInput = ({ label, source }) => (
   </ReferenceArrayInput>
 );
 
-export const ThemesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Theme" source={source}>
+export const ThemesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Theme" source={source} {...rest}>
     <AutocompleteArrayInput
       optionText="pair:label"
       shouldRenderSuggestions={(value) => value.length > 1}
@@ -102,14 +102,14 @@ export const ThemesInput = ({ label, source }) => (
   </ReferenceArrayInput>
 );
 
-export const UsersInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Person" source={source}>
+export const UsersInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Person" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const AgentsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Agent" source={source}>
+export const AgentsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Agent" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
@@ -138,8 +138,8 @@ export const PlaceInput = ({ label, source, ...rest }) => (
   </ReferenceInput>
 );
 
-export const CoursesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Course" source={source}>
+export const CoursesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Course" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
@@ -162,8 +162,8 @@ export const RegionsInput = ({ label, source, ...rest }) => (
   </ReferenceArrayInput>
 );
 
-export const TargetAudienceInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="TargetAudience" source={source}>
+export const TargetAudienceInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="TargetAudience" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );

--- a/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Course/CourseEdit.js
@@ -25,12 +25,11 @@ import frLocale from 'date-fns/locale/fr';
 const CourseEdit = (props) => (
   <EditWithPermissions title={<CourseTitle />} {...props}>
     <TabbedForm redirect="show">
-      <FormTab label="Données">
-        <TextInput source="pair:label" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
+      <FormTab label="A propos du voyage">
         <ImageInput source="pair:depictedBy" accept="image/*" multiple>
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:label" fullWidth />        
         <DateInput
           source="pair:startDate"
           options={{
@@ -51,6 +50,7 @@ const CourseEdit = (props) => (
           }}
           fullWidth
         />
+        <TextInput source="pair:comment" fullWidth />
         <MarkdownInput source="pair:description" fullWidth />
         <TargetAudienceInput source="cdlt:hasTargetAudience" fullWidth/>
         <MarkdownInput source="cdlt:organizerDescription" fullWidth />
@@ -70,19 +70,19 @@ const CourseEdit = (props) => (
           registrationLinkSource="cdlt:registrationLink"          
           fullWidth
         />
-      </FormTab>
-      <FormTab label="Relations">
-        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
-        <EventsInput source="pair:hasPart" fullWidth />
-        <PathsInput source="cdlt:courseOn" />
+        <FinalitiesInput source="pair:hasFinality" />
         <SectorsInput source="pair:hasSector" />
         <ThemesInput source="pair:hasTopic" />
         <SkillsInput source="cdlt:requiredSkills" />
         <SkillsInput source="pair:produces" />
+        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
+      </FormTab>
+      <FormTab label="En lien avec le voyage">
+        <EventsInput source="pair:hasPart" fullWidth />
         <ActorsInput source="cdlt:organizedBy" />
         <PersonsInput source="cdlt:hasMentor" />
+        <PathsInput source="cdlt:courseOn" />
         {/*<DocumentsType source="pair:documentedBy" />*/}
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth helperText="Non visible sur la plateforme" validate={[email()]} />

--- a/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
+++ b/backoffice/src/resources/Agent/Activity/Event/EventEdit.js
@@ -26,9 +26,11 @@ import EventTitle from './EventTitle';
 const EventEdit = (props) => (
   <EditWithPermissions title={<EventTitle />} {...props}>
     <TabbedForm redirect="show">
-      <FormTab label="Données">
+      <FormTab label="A propos de l'événement">
+        <ImageInput source="pair:depictedBy" accept="image/*" multiple>
+          <ImageField source="src" />
+        </ImageInput>
         <TextInput source="pair:label" fullWidth validate={[required()]} />
-        <TextInput source="pair:comment" fullWidth validate={[required()]} />
         <DateTimeInput
           source="pair:startDate"
           options={{
@@ -53,10 +55,10 @@ const EventEdit = (props) => (
           fullWidth
           validate={[required()]}
         />
-        <ImageInput source="pair:depictedBy" accept="image/*" multiple>
-          <ImageField source="src" />
-        </ImageInput>
+        <PairLocationInput source="pair:hasLocation" fullWidth />
+        <TextInput source="pair:comment" fullWidth validate={[required()]} />
         <MarkdownInput source="pair:description" fullWidth validate={[required()]} />
+        
         <TargetAudienceInput source="cdlt:hasTargetAudience" fullWidth/>
         <MarkdownInput source="cdlt:organizerDescription" fullWidth />
         <MarkdownInput source="cdlt:mentorDescription" fullWidth />
@@ -78,8 +80,6 @@ const EventEdit = (props) => (
         <TextInput multiline source="cdlt:financialSupport" helperText="Si éligible, précisez les types de financements (CPF, Qualiopi...)" fullWidth />
         <TextInput multiline source="cdlt:evaluationMethod" fullWidth />
         
-        <PairLocationInput source="pair:hasLocation" fullWidth />
-        
         <RegistrationInput 
           directRegistrationSource="cdlt:directRegistration"
           registrationOptionSource="cdlt:registrationOption"
@@ -87,24 +87,22 @@ const EventEdit = (props) => (
           registrationLinkSource="cdlt:registrationLink"          
           fullWidth
         />
-
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="cdlt:requiredSkills" />
+        <SkillsInput source="pair:produces" />
+        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} fullWidth />
+        <TypesInput source="pair:hasType" filter={{ a: 'pair:EventType' }} validate={[required()]} fullWidth />
         <ReminderBeforeRecording />
-
       </FormTab>
 
-      <FormTab label="Relations">
+      <FormTab label="En lien avec l'événement">
         <ActorsInput source="cdlt:organizedBy" />
         <PersonsInput source="cdlt:hasMentor" />
         <PlaceInput source="pair:hostedIn" fullWidth />
         <CoursesInput source="pair:partOf" fullWidth />
         <PathsInput source="cdlt:eventOn" />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
-        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} fullWidth />
-        <TypesInput source="pair:hasType" filter={{ a: 'pair:EventType' }} validate={[required()]} fullWidth />
-        <SkillsInput source="cdlt:requiredSkills" />
-        <SkillsInput source="pair:produces" />
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth helperText="Non visible sur la plateforme" validate={[required(), email()]} />

--- a/backoffice/src/resources/Agent/Actor/Organization/OrganizationEdit.js
+++ b/backoffice/src/resources/Agent/Actor/Organization/OrganizationEdit.js
@@ -24,34 +24,35 @@ export const OrganizationEdit = (props) => (
     <TabbedForm
       redirect="show"
     >
-      <FormTab label="Principal">
-        <TextInput source="pair:label" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
-        <TextInput source="pair:homePage" fullWidth />
-        <ImageInput source="pair:depictedBy" accept="image/*">
+      <FormTab label="A propos de l'organisation">
+      <ImageInput source="pair:depictedBy" accept="image/*">
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:label" fullWidth />
+        <TextInput source="pair:homePage" fullWidth />
+        <TextInput source="pair:e-mail" fullWidth />
+        <PairLocationInput source="pair:hasLocation" fullWidth />
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
         <MarkdownInput source="cdlt:intentions" fullWidth />
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="pair:produces" fullWidth />
+        <SkillsInput source="pair:aims" fullWidth />        
         <MarkdownInput source="cdlt:practicalConditions" fullWidth />
         <NumberInput source="cdlt:maximumCapacity" fullWidth />
         <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
         <TypesInput source="pair:hasType" filter={{ a: 'pair:OrganizationType' }} />
-        <PairLocationInput source="pair:hasLocation" fullWidth />
         <ReminderBeforeRecording />
       </FormTab>
-      <FormTab label="Relations">
+      <FormTab label="En lien avec l'organisation">
         <OrganizationsInput source="pair:partnerOf" />
         <OrganizationsInput source="pair:inspiredBy" />
-        <UsersInput source="pair:affiliates" />
-        <ActivitiesInput source="cdlt:organizes" />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
-        <PathsInput source="cdlt:supports" />
         <PlacesInput source="cdlt:organizationHostedIn" fullWidth />
-        <SkillsInput source="pair:produces" fullWidth />
-        <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
+        <ActivitiesInput source="cdlt:organizes" />
+        <UsersInput source="pair:affiliates" />
+        <PathsInput source="cdlt:supports" />  
       </FormTab>
     </TabbedForm>
   </EditWithPermissions>

--- a/backoffice/src/resources/Agent/Actor/Person/PersonEdit.js
+++ b/backoffice/src/resources/Agent/Actor/Person/PersonEdit.js
@@ -32,18 +32,24 @@ export const PersonEdit = (props) => (
     {...props}
   >
     <TabbedForm redirect="show">
-      <FormTab label="Principal">
-        <TextInput source="pair:firstName" fullWidth />
-        <TextInput source="pair:lastName" fullWidth />
-        <TextInput source="pair:alternativeLabel" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
-        <TextInput source="pair:homePage" fullWidth />
+      <FormTab label="A propos de la personne">
         <ImageInput source="pair:depictedBy" accept="image/*">
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:firstName" fullWidth />
+        <TextInput source="pair:lastName" fullWidth />
+        <TextInput source="pair:alternativeLabel" fullWidth />
+        <TextInput source="pair:homePage" fullWidth />
+        <TextInput source="pair:phone" fullWidth />
+        <PairLocationInput source="pair:hasLocation" fullWidth />
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
         <MarkdownInput source="cdlt:intentions" fullWidth />
-        <TextInput source="pair:phone" fullWidth helperText="Non visible sur la plateforme" />
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="pair:offers" />
+        <SkillsInput source="pair:aims" fullWidth />
         <TypeInput source="pair:hasType" filter={{ a: 'pair:PersonType' }} />
         <StatusInput source="pair:hasStatus" filter={{ a: 'pair:AgentStatus' }} />
         <PairLocationInput source="pair:hasLocation" fullWidth />
@@ -55,18 +61,13 @@ export const PersonEdit = (props) => (
         */}
         <ReminderBeforeRecording />
       </FormTab>
-      <FormTab label="Relations">
+      <FormTab label="En lien avec la personne">
         <OrganizationsInput source="pair:affiliatedBy" />
         <OrganizationsInput source="pair:inspiredBy" />
         <PlacesInput source="cdlt:proposes" />
-        <ActivitiesInput source="cdlt:mentorOn" />
         <ActivitiesInput source="cdlt:organizes" />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
+        <ActivitiesInput source="cdlt:mentorOn" />
         <PathsInput source="cdlt:supports" />
-        <SkillsInput source="pair:offers" />
-        <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
     </TabbedForm>
   </EditWithPermissions>

--- a/backoffice/src/resources/Idea/Path/PathEdit.js
+++ b/backoffice/src/resources/Idea/Path/PathEdit.js
@@ -20,26 +20,26 @@ import PathTitle from './PathTitle';
 const PathEdit = (props) => (
   <EditWithPermissions title={<PathTitle />} {...props}>
     <TabbedForm redirect="show">
-      <FormTab label="Données">
-        <TextInput source="pair:label" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
+      <FormTab label="A propos du chemin">
         <ImageInput source="pair:depictedBy" accept="image/*" multiple>
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:label" fullWidth />
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
         <MarkdownInput source="cdlt:learningObjectives" fullWidth />
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="pair:produces" />
+        <TypeInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} fullWidth />
       </FormTab>
-      <FormTab label="Relations">
+      <FormTab label="En lien avec le chemin">
+        <PersonsInput source="cdlt:proposedBy" />
+        <OrganizationsInput source="cdlt:supportedBy" />
         <PlacesInput source="cdlt:hasPlace" />
         <EventsInput source="cdlt:hasEvent" />
         <CoursesInput source="cdlt:hasCourse" />
-        <PersonsInput source="cdlt:proposedBy" />
-        <OrganizationsInput source="cdlt:supportedBy" />
-        <SkillsInput source="pair:produces" />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
-        <TypeInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
     </TabbedForm>
   </EditWithPermissions>

--- a/backoffice/src/resources/Place/PlaceEdit.js
+++ b/backoffice/src/resources/Place/PlaceEdit.js
@@ -22,17 +22,11 @@ import ReminderBeforeRecording from '../../commons/ReminderBeforeRecording';
 export const PlaceEdit = (props) => (
   <EditWithPermissions title={<PlaceTitle />} {...props}>
     <TabbedForm redirect="show">
-      <FormTab label="Données">
-        <TextInput source="pair:label" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
+      <FormTab label="A propos du lieu">
         <ImageInput source="pair:depictedBy" accept="image/*" multiple>
           <ImageField source="src" />
         </ImageInput>
-        <MarkdownInput source="pair:description" fullWidth />
-        <MarkdownInput source="cdlt:hostDescription" fullWidth />
-        <MarkdownInput source="cdlt:activities" fullWidth />
-        <MarkdownInput source="cdlt:practicalConditions" fullWidth />
-        <NumberInput source="cdlt:maximumCapacity" fullWidth />
+        <TextInput source="pair:label" fullWidth />
         <LocationInput
           mapboxConfig={{
             access_token: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN,
@@ -54,6 +48,12 @@ export const PlaceEdit = (props) => (
           optionText={(resource) => resource['pair:label']}
           fullWidth
         />
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
+        <MarkdownInput source="cdlt:hostDescription" fullWidth />
+        <MarkdownInput source="cdlt:activities" fullWidth />
+        <MarkdownInput source="cdlt:practicalConditions" fullWidth />
+        <NumberInput source="cdlt:maximumCapacity" fullWidth />
         <RegistrationInput 
           directRegistrationSource="cdlt:directRegistration"
           registrationOptionSource="cdlt:registrationOption"
@@ -61,21 +61,22 @@ export const PlaceEdit = (props) => (
           registrationLinkSource="cdlt:registrationLink"          
           fullWidth
         />
-        <ReminderBeforeRecording />
-      </FormTab>
-      <FormTab label="Relations">
-        <PersonsInput source="cdlt:proposedBy" />
-        <PathsInput source="cdlt:placeOn" />
+        <FinalitiesInput source="pair:hasFinality" />
         <SectorsInput source="pair:hasSector" />
         <ThemesInput source="pair:hasTopic" />
-        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
-        <TypesInput source="pair:hasType" filter={{ a: 'pair:PlaceType' }} />
-        {/*<StatusInput source="pair:hasStatus" filter={{ a: 'pair:PlaceStatus' }} />*/}
-        {/*<EventsInput source="pair:hosts" fullWidth />*/}
         <SkillsInput source="pair:produces" fullWidth />
         <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
+        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
+        <TypesInput source="pair:hasType" filter={{ a: 'pair:PlaceType' }} />
+        
+        <ReminderBeforeRecording />
+      </FormTab>
+      <FormTab label="En lien avec le lieu">
+        {/*<StatusInput source="pair:hasStatus" filter={{ a: 'pair:PlaceStatus' }} />*/}
+        {/*<EventsInput source="pair:hosts" fullWidth />*/}
         <OrganizationsInput source="cdlt:hostsOrganization" />
+        <PersonsInput source="cdlt:proposedBy" />
+        <PathsInput source="cdlt:placeOn" />
       </FormTab>
       <FormTab label="Contact">
         <TextInput source="pair:e-mail" fullWidth helperText="Non visible sur la plateforme" validate={[required(), email()]} />  

--- a/frontoffice/src/pair/index.js
+++ b/frontoffice/src/pair/index.js
@@ -3,14 +3,14 @@ import { ReferenceArrayInput, ReferenceInput } from '@semapps/semantic-data-prov
 import { AutocompleteInput, AutocompleteArrayInput, SelectInput } from 'react-admin';
 import { LexiconCreateDialog, fetchESCO, fetchWikidata } from "@semapps/interop-components";
 
-export const ActorsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Actor" source={source}>
+export const ActorsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Actor" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
 
-export const OrganizationsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Organization" source={source}>
+export const OrganizationsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Organization" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
@@ -21,8 +21,8 @@ export const PersonsInput = (props) => (
   </ReferenceArrayInput>
 );
 
-export const ActivitiesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Activity" source={source}>
+export const ActivitiesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Activity" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );
@@ -39,20 +39,20 @@ export const PlacesInput = (props) => (
   </ReferenceArrayInput>
 );
 
-export const FinalitiesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Finality" source={source}>
+export const FinalitiesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Finality" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const SectorsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Sector" source={source}>
+export const SectorsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Sector" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" fullWidth />
   </ReferenceArrayInput>
 );
 
-export const SkillsInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Skill" source={source}>
+export const SkillsInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Skill" source={source} {...rest}>
     <AutocompleteArrayInput
       optionText="pair:label"
       shouldRenderSuggestions={(value) => value.length > 1}
@@ -70,8 +70,8 @@ export const SkillsInput = ({ label, source }) => (
   </ReferenceArrayInput>
 );
 
-export const ThemesInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Theme" source={source}>
+export const ThemesInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Theme" source={source} {...rest}>
     <AutocompleteArrayInput
       optionText="pair:label"
       shouldRenderSuggestions={(value) => value.length > 1}
@@ -90,8 +90,8 @@ export const ThemesInput = ({ label, source }) => (
   </ReferenceArrayInput>
 );
 
-export const UsersInput = ({ label, source }) => (
-  <ReferenceArrayInput label={label} reference="Person" source={source}>
+export const UsersInput = ({ label, source, ...rest }) => (
+  <ReferenceArrayInput label={label} reference="Person" source={source} {...rest}>
     <AutocompleteArrayInput optionText="pair:label" shouldRenderSuggestions={(value) => value.length > 1} fullWidth />
   </ReferenceArrayInput>
 );

--- a/frontoffice/src/resources/Activity/Event/EventForm.js
+++ b/frontoffice/src/resources/Activity/Event/EventForm.js
@@ -153,8 +153,10 @@ const EventForm = ({ mode, ...rest }) => {
       {...rest}
       redirect="show"
     >
-      <FormTab label="Données" className={classes.formTab}>
-
+      <FormTab label="A propos de l'événement" className={classes.formTab}>
+        <ImageInput source="pair:depictedBy" accept="image/*" multiple>
+          <ImageField source="src" />
+        </ImageInput>
         <TextInput source="pair:label" fullWidth validate={[required()]} />
         { ['create', 'duplicate'].includes(mode)  &&
           <Box className={classes.duplicateContainer}>
@@ -189,7 +191,6 @@ const EventForm = ({ mode, ...rest }) => {
             }
           </Box>
         }
-        <TextInput source="pair:comment" fullWidth validate={[required()]} />
         <DateTimeInput
           source="pair:startDate"
           options={{
@@ -213,10 +214,9 @@ const EventForm = ({ mode, ...rest }) => {
           }}
           fullWidth
           validate={[required()]}
-        />
-        <ImageInput source="pair:depictedBy" accept="image/*" multiple>
-          <ImageField source="src" />
-        </ImageInput>
+        /> 
+        <PairLocationInput source="pair:hasLocation" fullWidth />
+        <TextInput source="pair:comment" fullWidth validate={[required()]} />
         <MarkdownInput source="pair:description" fullWidth validate={[required()]} />
         <TargetAudienceInput source="cdlt:hasTargetAudience" fullWidth />
         <MarkdownInput source="cdlt:organizerDescription" fullWidth />
@@ -239,7 +239,6 @@ const EventForm = ({ mode, ...rest }) => {
         <TextInput multiline helperText="Si éligible, précisez les types de financements (CPF, Qualiopi...)" source="cdlt:financialSupport" fullWidth />
         <TextInput multiline source="cdlt:evaluationMethod" fullWidth />
 
-        <PairLocationInput source="pair:hasLocation" fullWidth />
         <RegistrationInput 
           directRegistrationSource="cdlt:directRegistration"
           registrationOptionSource="cdlt:registrationOption"
@@ -247,21 +246,22 @@ const EventForm = ({ mode, ...rest }) => {
           registrationLinkSource="cdlt:registrationLink"          
           fullWidth
         />
+
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="cdlt:requiredSkills" fullWidth />
+        <SkillsInput source="pair:produces" fullWidth />
+        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} fullWidth />
+        <TypesInput source="pair:hasType" filter={{ a: 'pair:EventType' }} validate={[required()]} fullWidth />
         <ReminderBeforeRecording />
       </FormTab>
-      <FormTab label="Relations" className={classes.formTab}>
+      <FormTab label="En lien avec l'événement" className={classes.formTab}>
         <ActorsInput source="cdlt:organizedBy" />
         <PersonsInput source="cdlt:hasMentor" />
         <PlaceInput source="pair:hostedIn" fullWidth />
         <CoursesInput source="pair:partOf" fullWidth />
         <PathsInput source="cdlt:eventOn" fullWidth />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
-        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} fullWidth />
-        <TypesInput source="pair:hasType" filter={{ a: 'pair:EventType' }} validate={[required()]} fullWidth />
-        <SkillsInput source="cdlt:requiredSkills" fullWidth />
-        <SkillsInput source="pair:produces" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
       <FormTab label="Contact" className={classes.formTab}>
         <TextInput source="pair:e-mail" fullWidth helperText="Non visible sur la plateforme" validate={[required(), email()]} />

--- a/frontoffice/src/resources/Agent/Actor/Organization/OrganizationForm.js
+++ b/frontoffice/src/resources/Agent/Actor/Organization/OrganizationForm.js
@@ -25,35 +25,35 @@ const OrganizationForm = ({ mode, ...rest }) => {
       {...rest}
       redirect="show"
     >
-      <FormTab label="Principal">
-        <TextInput source="pair:label" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
-        <TextInput source="pair:homePage" fullWidth />
-        <TextInput source="pair:e-mail" fullWidth />
+      <FormTab label="A propos de l'organisation">
         <ImageInput source="pair:depictedBy" accept="image/*">
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:label" fullWidth />
+        <TextInput source="pair:homePage" fullWidth />
+        <TextInput source="pair:e-mail" fullWidth />
+        <PairLocationInput source="pair:hasLocation" fullWidth />
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
         <MarkdownInput source="cdlt:intentions" fullWidth />
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="pair:produces" fullWidth />
+        <SkillsInput source="pair:aims" fullWidth />        
         <MarkdownInput source="cdlt:practicalConditions" fullWidth />
         <NumberInput source="cdlt:maximumCapacity" fullWidth />
         <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} />
         <TypesInput source="pair:hasType" filter={{ a: 'pair:OrganizationType' }} />
-        <PairLocationInput source="pair:hasLocation" fullWidth />
         <ReminderBeforeRecording />
       </FormTab>
-      <FormTab label="Relations">
+      <FormTab label="En lien avec l'organisation">
         <OrganizationsInput source="pair:partnerOf" />
         <OrganizationsInput source="pair:inspiredBy" />
-        <UsersInput source="pair:affiliates" />
-        <ActivitiesInput source="cdlt:organizes" />
-        <PathsInput source="cdlt:supports" />
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
         <PlacesInput source="cdlt:organizationHostedIn" fullWidth />
-        <SkillsInput source="pair:produces" fullWidth />
-        <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
+        <ActivitiesInput source="cdlt:organizes" />
+        <UsersInput source="pair:affiliates" />
+        <PathsInput source="cdlt:supports" />    
       </FormTab>
     </TabbedForm>
   );

--- a/frontoffice/src/resources/Agent/Actor/Person/PersonForm.js
+++ b/frontoffice/src/resources/Agent/Actor/Person/PersonForm.js
@@ -24,23 +24,29 @@ const PersonForm = ({ ...rest }) => {
 
   return (
     <TabbedForm {...rest} redirect="show">
-      <FormTab label="Principal">
-        <TextInput source="pair:firstName" fullWidth />
-        <TextInput source="pair:lastName" fullWidth />
-        <TextInput source="pair:alternativeLabel" fullWidth />
-        <TextInput source="pair:comment" fullWidth />
-        <MarkdownInput source="pair:description" fullWidth />
-        <TextInput source="pair:homePage" fullWidth />
+      <FormTab label="A propos de vous">
         <ImageInput source="pair:depictedBy" accept="image/*">
           <ImageField source="src" />
         </ImageInput>
+        <TextInput source="pair:firstName" fullWidth />
+        <TextInput source="pair:lastName" fullWidth />
+        <TextInput source="pair:alternativeLabel" fullWidth helperText="Renseignez un nom d'utilisateur pour que votre nom n'apparaisse pas publiquement" />
+        <TextInput source="pair:homePage" fullWidth helperText="Un lien sur le web ? (Site web, réseau social...)"/>
+        <TextInput source="pair:phone" fullWidth helperText="Ne s'affichera pas publiquement" />
+        <PairLocationInput source="pair:hasLocation" fullWidth helperText="Renseignez au choix une adresse précise ou seulement une commune"/>
+        <TextInput source="pair:comment" fullWidth />
+        <MarkdownInput source="pair:description" fullWidth />
         <MarkdownInput source="cdlt:intentions" fullWidth />
-        <TextInput source="pair:phone" fullWidth helperText="Non visible sur la plateforme" />
+        <FinalitiesInput source="pair:hasFinality" />
+        <SectorsInput source="pair:hasSector" />
+        <ThemesInput source="pair:hasTopic" />
+        <SkillsInput source="pair:offers" />
+        <SkillsInput source="pair:aims" fullWidth />
         {/*
         <TypeInput source="pair:hasType" filter={{ a: 'pair:PersonType' }} />
         <StatusInput source="pair:hasStatus" filter={{ a: 'pair:AgentStatus' }} />
         */}
-        <PairLocationInput source="pair:hasLocation" fullWidth />
+        
         {/*
         <MarkdownInput source="cdlt:asAHostIntentions" fullWidth />
         <MarkdownInput source="cdlt:asAMentorIntentions" fullWidth />
@@ -49,22 +55,17 @@ const PersonForm = ({ ...rest }) => {
         */}
         <ReminderBeforeRecording />
       </FormTab>
-      <FormTab label="Relations">
+      <FormTab label="En lien avec vous">
         { ! isTraveler && 
           <>
-            <OrganizationsInput source="pair:affiliatedBy" />
-            <OrganizationsInput source="pair:inspiredBy" />
-            <PlacesInput source="cdlt:proposes" />
-            <ActivitiesInput source="cdlt:mentorOn" />
-            <ActivitiesInput source="cdlt:organizes" />
-            <PathsInput source="cdlt:supports" />
+            <OrganizationsInput source="pair:affiliatedBy" helperText="Tu es membre d'une ou plusieurs organisations ?"/>
+            <OrganizationsInput source="pair:inspiredBy" helperText="Des personnes t'inspirent ?"/>
+            <PlacesInput source="cdlt:proposes" helperText="Tu es l'hôte d'un lieu ?"/>
+            <ActivitiesInput source="cdlt:organizes" helperText="Tu contribues à l'organisation d'un évenement ou d'un voyage ?"/>
+            <ActivitiesInput source="cdlt:mentorOn" helperText="Tu es intervenant sur un évenement ou un voyage ?"/>
+            <PathsInput source="cdlt:supports" helperText="Tu contribues à la construction d'un chemin ?"/>
           </>
         }
-        <SectorsInput source="pair:hasSector" />
-        <ThemesInput source="pair:hasTopic" />
-        <SkillsInput source="pair:offers" />
-        <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
       </FormTab>
     </TabbedForm>
   );

--- a/frontoffice/src/resources/Agent/Actor/Person/index.js
+++ b/frontoffice/src/resources/Agent/Actor/Person/index.js
@@ -30,15 +30,15 @@ export default {
         'pair:alternativeLabel': 'Nom d\'utilisateur',
         'pair:comment': 'En quelques mots',
         'pair:description': 'Description',
-        'pair:homePage': 'Site web',
+        'pair:homePage': 'Site internet',
         'pair:depictedBy': 'Photo',
         'pair:hasType': 'Type',
         'pair:hasStatus': 'Statut',
-        'pair:hasSector': 'Secteurs d\'activité',
-        'pair:hasTopic': 'Mots clé', /*Theme*/
+        'pair:hasSector': "Vos secteurs d'activité",
+        'pair:hasTopic': "Les mots-clés (centres d'intérêts) qui vous caractérisent", /*Theme*/
         'pair:hasLocation': 'Localisation',
-        'pair:hasFinality': 'Finalités',
-        'cdlt:intentions': 'Mes intentions en venant sur les chemins de la transition',
+        'pair:hasFinality': 'Les finalités que vous poursuivez',
+        'cdlt:intentions': 'Vos intentions en venant sur les chemins de la transition',
         /*
         'cdlt:asAHostIntentions': 'Intention en tant qu\'hôte',
         'cdlt:asAMentorIntentions': 'Intention en tant qu\'intervenant.e',
@@ -51,8 +51,8 @@ export default {
         'cdlt:proposes': 'Est hôte de',
         'foaf:email': 'Adresse email',
         'pair:phone': 'Téléphone',
-        'pair:offers': 'Compétences actuelles', /*Skill*/
-        'pair:aims': 'Compétences recherchées', /*Skill*/
+        'pair:offers': 'Vos compétences actuelles', /*Skill*/
+        'pair:aims': 'Les compétences que vous recherchez', /*Skill*/
         'pair:inspiredBy': 'Est inspirée par', /*Organization*/
         'cdlt:supports': 'Chemins', /*Paths*/
       },

--- a/frontoffice/src/resources/Place/PlaceForm.js
+++ b/frontoffice/src/resources/Place/PlaceForm.js
@@ -25,18 +25,11 @@ const PlaceForm = ({ mode, ...rest }) => {
       {...rest}
       redirect="show"
     >
-      <FormTab label="Données">
-
-        <TextInput source="pair:label" fullWidth validate={[required()]} />
-        <TextInput source="pair:comment" fullWidth validate={[required()]} />
+      <FormTab label="A propos du lieu">
         <ImageInput source="pair:depictedBy" accept="image/*" multiple>
           <ImageField source="src" />
         </ImageInput>
-        <MarkdownInput source="pair:description" fullWidth validate={[required()]} isRequired />
-        <MarkdownInput source="cdlt:hostDescription" fullWidth />
-        <MarkdownInput source="cdlt:activities" fullWidth />
-        <MarkdownInput source="cdlt:practicalConditions" fullWidth />
-        <NumberInput source="cdlt:maximumCapacity" fullWidth />
+        <TextInput source="pair:label" fullWidth validate={[required()]} />
         <LocationInput
           mapboxConfig={{
             access_token: process.env.REACT_APP_MAPBOX_ACCESS_TOKEN,
@@ -58,6 +51,12 @@ const PlaceForm = ({ mode, ...rest }) => {
           validate={[required()]}
           fullWidth
         />
+        <TextInput source="pair:comment" fullWidth validate={[required()]} />
+        <MarkdownInput source="pair:description" fullWidth validate={[required()]} isRequired />
+        <MarkdownInput source="cdlt:hostDescription" fullWidth />
+        <MarkdownInput source="cdlt:activities" fullWidth />
+        <MarkdownInput source="cdlt:practicalConditions" fullWidth />
+        <NumberInput source="cdlt:maximumCapacity" fullWidth />
         <RegistrationInput 
             directRegistrationSource="cdlt:directRegistration"
             registrationOptionSource="cdlt:registrationOption"
@@ -65,20 +64,20 @@ const PlaceForm = ({ mode, ...rest }) => {
             registrationLinkSource="cdlt:registrationLink"          
             fullWidth
         />
-        <ReminderBeforeRecording />
-      </FormTab>
-      <FormTab label="Relations">
-        <PersonsInput source="cdlt:proposedBy" fullWidth />
-        <PathsInput source="cdlt:placeOn" fullWidth />
+        <FinalitiesInput source="pair:hasFinality" />
         <SectorsInput source="pair:hasSector" fullWidth />
         <ThemesInput source="pair:hasTopic" fullWidth />
-        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} />        
-        <TypesInput source="pair:hasType" filter={{ a: 'pair:PlaceType' }} validate={[required()]} />
-        {/*<StatusInput source="pair:hasStatus" filter={{ a: 'pair:PlaceStatus' }} fullWidth />*/}
         <SkillsInput source="pair:produces" fullWidth />
         <SkillsInput source="pair:aims" fullWidth />
-        <FinalitiesInput source="pair:hasFinality" />
+        <TypesInput source="cdlt:hasCourseType" filter={{ a: 'cdlt:CourseType' }} validate={[required()]} />        
+        <TypesInput source="pair:hasType" filter={{ a: 'pair:PlaceType' }} validate={[required()]} />
+        <ReminderBeforeRecording />
+      </FormTab>
+      <FormTab label="En lien avec le lieu">
+        {/*<StatusInput source="pair:hasStatus" filter={{ a: 'pair:PlaceStatus' }} fullWidth />*/}       
         <OrganizationsInput source="cdlt:hostsOrganization" />
+        <PersonsInput source="cdlt:proposedBy" fullWidth />
+        <PathsInput source="cdlt:placeOn" fullWidth />
       </FormTab>
       <FormTab label="Contact">
       <TextInput source="pair:e-mail" fullWidth helperText="Non visible sur la plateforme" validate={[required(), email()]} />  


### PR DESCRIPTION
@GuillaumeAV 
Du coup j'ai changé l'ordre des champs d'édition des Personnes/Orgas/Evénements/Voyages/Lieux/Chemins en me basant sur les catégories que tu avais indiquées, donc à peu près dans cet ordre-là (en fonction des champs présents dans chacun) :
* A propos de ...
-photo
-noms/titre
-(contacts), adresse
-comment, description, tous les détails spécifiques
-intentions/finalités
-secteurs/mots clés
-compétences
-types de voyage/événement
* En lien avec ...
tous les liens avec autres entités (orga, personnes, lieux, voyages, events, chemins)
* (Contact)

Peux-tu valider si c'est bien cela ?