### PR TITLE
462_reinitialiser_filtres

### DIFF
--- a/frontoffice/src/commons/SearchFilter.js
+++ b/frontoffice/src/commons/SearchFilter.js
@@ -28,7 +28,7 @@ const SearchFilter = () => {
   useEffect(() => {
     if (!filterValues.q) {textInput.current.value=""}
     if (filterValues.q && textInput.current.value==="") {textInput.current.value=filterValues.q}
-  }, [filterValues, setFilters]);
+  }, [filterValues, textInput ]);
   
   return (  
     <FormControl className={classes.formControl}>

--- a/frontoffice/src/commons/SearchFilter.js
+++ b/frontoffice/src/commons/SearchFilter.js
@@ -22,13 +22,13 @@ const SearchFilter = () => {
   const textInput = useRef(null);
 
   const changeFilter = debounce(query => {
-    if (!query) return setFilters(filterValues, null, false);
     setFilters({ ...filterValues, q: query}, null, false);
   }, 500)
 
   useEffect(() => {
     if (!filterValues.q) {textInput.current.value=""}
-  }, [filterValues]);
+    if (filterValues.q && textInput.current.value==="") {textInput.current.value=filterValues.q}
+  }, [filterValues, setFilters]);
   
   return (  
     <FormControl className={classes.formControl}>

--- a/frontoffice/src/commons/SparqlFilter.js
+++ b/frontoffice/src/commons/SparqlFilter.js
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { useListFilterContext } from 'react-admin';
 import { Checkbox, FormControlLabel, FormGroup, makeStyles } from '@material-ui/core';
 
@@ -34,6 +34,10 @@ const SparqlFilter = ({ checked, setChecked, sparqlWhere, label }) => {
     },
     [filterValues, setFilters, sparqlWhere, setChecked]
   );
+
+  useEffect(() => {
+    if (!filterValues.sparqlWhere) {setChecked(false)}
+  }, [filterValues, setFilters, setChecked]);
 
   return (
     <FormGroup className={classes.formGroup}>

--- a/frontoffice/src/commons/SparqlFilter.js
+++ b/frontoffice/src/commons/SparqlFilter.js
@@ -37,7 +37,7 @@ const SparqlFilter = ({ checked, setChecked, sparqlWhere, label }) => {
 
   useEffect(() => {
     if (!filterValues.sparqlWhere) {setChecked(false)}
-  }, [filterValues, setFilters, setChecked]);
+  }, [filterValues, setChecked]);
 
   return (
     <FormGroup className={classes.formGroup}>

--- a/frontoffice/src/resources/Activity/Event/EventList.js
+++ b/frontoffice/src/resources/Activity/Event/EventList.js
@@ -52,7 +52,7 @@ const EventList = (props) => {
           icon: ListIcon,
           perPage: 1000,
           sort: { field: 'pair:startDate', order: 'ASC' },
-          filterDefaultValues: { sparqlWhere: futureEventSparql },
+          filterDefaultValues: { sparqlWhere: futureEventSparql, dereference: [] },
           list: (
             <Box p={xs ? 2 : 3}>
               <CardsList CardComponent={EventCard} />

--- a/frontoffice/src/resources/Activity/Event/EventList.js
+++ b/frontoffice/src/resources/Activity/Event/EventList.js
@@ -52,7 +52,7 @@ const EventList = (props) => {
           icon: ListIcon,
           perPage: 1000,
           sort: { field: 'pair:startDate', order: 'ASC' },
-          filterDefaultValues: { sparqlWhere: futureEventSparql, dereference: [] },
+          filterDefaultValues: { sparqlWhere: futureEventSparql },
           list: (
             <Box p={xs ? 2 : 3}>
               <CardsList CardComponent={EventCard} />


### PR DESCRIPTION
* Si on efface la requête de la barre de recherche, ça réinitialise cette requête
* Si on change de page et revient, les mêmes filtres sont conservés et affichés (il y avait un bug, les filtres restaient mais l'affichage de la barre de recherche et de la case ne correspondaient plus)