### PR TITLE
624 hide all unpublished data

### DIFF
--- a/backoffice/src/config/constants.js
+++ b/backoffice/src/config/constants.js
@@ -1,0 +1,2 @@
+export const PUBLISHED_STATUS = process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide';
+export const UNPUBLISHED_STATUS = process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/en-cours';

--- a/backoffice/src/config/messages/en.js
+++ b/backoffice/src/config/messages/en.js
@@ -8,6 +8,8 @@ module.exports = {
       mapView: "map",
       publish: "publish",
       unpublish: "unpublish",
+      published: "La ressource a été publiée",
+      unpublished: "La ressource a été dépubliée",
     },
     page: {},
     card: {},

--- a/frontoffice/src/commons/RedirectIfUnpublished.js
+++ b/frontoffice/src/commons/RedirectIfUnpublished.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useRecordContext, useNotify, useRedirect } from 'react-admin';
+import { PUBLISHED_STATUS } from '../config/constants';
+
+const RedirectIfUnpublished = ({setIsPublished}) => {
+  const record = useRecordContext();
+  const redirect = useRedirect();
+  const notify = useNotify();
+  useEffect(() => {
+    if (record) {
+      if (record['cdlt:hasPublicationStatus'] !== PUBLISHED_STATUS) {
+        notify('auth.message.resource_show_forbidden' , { type: 'error' });
+        redirect('/');
+      } else {
+        setIsPublished(true);
+      }
+    }
+  }, [record, notify, redirect, setIsPublished]);
+  return;
+};
+
+export default RedirectIfUnpublished;

--- a/frontoffice/src/commons/ShowBaseOnlyIfPublished.js
+++ b/frontoffice/src/commons/ShowBaseOnlyIfPublished.js
@@ -1,0 +1,20 @@
+import React, { useState } from 'react';
+import { ShowBase } from 'react-admin';
+import RedirectIfUnpublished from './RedirectIfUnpublished';
+
+const ShowBaseOnlyIfPublished = ({children, ...props}) => {
+  const fields = React.Children.toArray(children);
+  const [isPublished, setIsPublished] = useState(false);
+  return (
+    <ShowBase {...props}>
+      <RedirectIfUnpublished setIsPublished={setIsPublished} />
+      {isPublished && fields.map((field) => (
+        <>
+          {React.cloneElement(field)}
+        </>
+      ))}
+    </ShowBase>
+  );
+};
+
+export default ShowBaseOnlyIfPublished;

--- a/frontoffice/src/commons/lists/CardsList.js
+++ b/frontoffice/src/commons/lists/CardsList.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useListContext, Loading, linkToRecord, Link } from 'react-admin';
 import { Box, Card, CardMedia, CardContent, makeStyles } from '@material-ui/core';
 import LikeButton from "../buttons/LikeButton";
+import { PUBLISHED_STATUS } from '../../config/constants';
 
 const useStyles = makeStyles((theme) => ({
   mainContainer: {
@@ -56,7 +57,7 @@ const CardsList = ({ CardComponent, link, hasLike, external, onlyFutureEvents, a
   ) : (
     ids.map((id) => {
       if (!data[id] || data[id]['_error']) return null;
-      if (!all && data[id]?.['cdlt:hasPublicationStatus'] !== process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide') return null;
+      if (!all && data[id]?.['cdlt:hasPublicationStatus'] !== PUBLISHED_STATUS) return null;
       if (onlyFutureEvents && data[id]?.['pair:startDate']<(new Date()).toISOString()) return null;
       const image = data[id]?.['pair:depictedBy'];
       const card =

--- a/frontoffice/src/commons/lists/EventsList/NextEvents.js
+++ b/frontoffice/src/commons/lists/EventsList/NextEvents.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react' ;
 import { makeStyles, Box, useMediaQuery } from '@material-ui/core';
-import { ListBase } from 'react-admin';
+import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 import EventItemsGrid from './EventItemsGrid';
 import AgendaFilter from './AgendaFilter';
 import useFutureEventSparql from "../../../hooks/useFutureEventSparql";
@@ -43,7 +43,7 @@ const NextEvents = ({ similarRecord }) => {
         setRegion={setRegion}
       />
       <Box className={classes.eventsBox}>
-      <ListBase
+      <ListBaseWithOnlyPublishedResources
         resource="Event"
         basePath="/Event"
         className={classes.eventListBase}
@@ -53,7 +53,7 @@ const NextEvents = ({ similarRecord }) => {
         sort={{ field: 'pair:startDate', order: 'ASC' }}
       >
         <EventItemsGrid similarRecord={similarRecord}/>
-      </ListBase>
+      </ListBaseWithOnlyPublishedResources>
       </Box>
     </>
   );

--- a/frontoffice/src/commons/lists/FeaturedList/FeaturedList.js
+++ b/frontoffice/src/commons/lists/FeaturedList/FeaturedList.js
@@ -3,7 +3,7 @@ import { makeStyles, Typography, Box, useMediaQuery } from '@material-ui/core';
 import FullWidthBox from '../../FullWidthBox';
 import LargeContainer from '../../LargeContainer';
 import ChevronRightIcon from '../../../svg/ChevronRightIcon';
-import { ListBase } from 'react-admin';
+import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 import { Link } from 'react-router-dom';
 import ItemsGrid from './ItemsGrid';
 import { linkToFilteredList } from "../../../utils";
@@ -139,9 +139,15 @@ const FeaturedList = ({ resource, basePath, title, subtitle, comment, logo, link
           </Box>
         : 
           <Box className={classes.listBase}>
-            <ListBase resource={resource} basePath={basePath} perPage={xs ? 10 : 4} sort={{ field: 'dc:created', order: 'DESC' }} filter={filter ? {[filter.field]:filter.value} : null}>
+            <ListBaseWithOnlyPublishedResources
+              resource={resource}
+              basePath={basePath}
+              perPage={xs ? 10 : 4}
+              sort={{ field: 'dc:created', order: 'DESC' }}
+              filter={filter ? {[filter.field]:filter.value} : null}
+            >
               <ItemsGrid CardSubHeaderComponent={CardSubHeaderComponent} resource={resource}/>
-            </ListBase>
+            </ListBaseWithOnlyPublishedResources>
           </Box>
         }
       </LargeContainer>

--- a/frontoffice/src/commons/lists/FeaturedList/SimilarList.js
+++ b/frontoffice/src/commons/lists/FeaturedList/SimilarList.js
@@ -3,7 +3,8 @@ import { makeStyles, Typography, Box } from '@material-ui/core';
 import FullWidthBox from '../../FullWidthBox';
 import LargeContainer from '../../LargeContainer';
 import ChevronRightIcon from '../../../svg/ChevronRightIcon';
-import {ListBase, useShowContext} from 'react-admin';
+import {useShowContext} from 'react-admin';
+import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 import { Link } from 'react-router-dom';
 import ItemsGrid from './ItemsGrid';
 
@@ -92,9 +93,12 @@ const SimilarList = ({ resource, basePath, title, subtitle, logo, headComment, l
           </Link>
         </Box>
         <Box className={classes.listBase}>
-          <ListBase resource={resource} basePath={basePath}>
+          <ListBaseWithOnlyPublishedResources
+            resource={resource}
+            basePath={basePath}
+          >
             <ItemsGrid similarRecord={record} CardSubHeaderComponent={CardSubHeaderComponent} />
-          </ListBase>
+          </ListBaseWithOnlyPublishedResources>
         </Box>
       </LargeContainer>
     </FullWidthBox>

--- a/frontoffice/src/commons/lists/ListBaseWithOnlyPublishedResources.js
+++ b/frontoffice/src/commons/lists/ListBaseWithOnlyPublishedResources.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { ListBase  } from 'react-admin';
+import { PUBLISHED_STATUS } from '../../config/constants';
+
+const ListBaseWithOnlyPublishedResources = ({filter, ...props}) => {
+  const publicationFilter = {'cdlt:hasPublicationStatus': PUBLISHED_STATUS};
+  return (
+    <ListBase
+      filter = {{ ...filter, ...publicationFilter }}
+      {...props}
+    />
+  );
+};
+
+export default ListBaseWithOnlyPublishedResources;

--- a/frontoffice/src/commons/lists/MultiViewsFilterList/MultiViewsFilterList.js
+++ b/frontoffice/src/commons/lists/MultiViewsFilterList/MultiViewsFilterList.js
@@ -1,5 +1,5 @@
 import React, {useState} from 'react';
-import { ListBase } from 'react-admin';
+import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 import { useLocation } from 'react-router';
 import MultiViewsFilterListView from "./MultiViewsFilterListView";
 
@@ -11,14 +11,14 @@ const MultiViewsFilterList = ({ views, filters, clearFilters, ...rest }) => {
   const [currentView, setView] = useState(initialView);
 
   return(
-    <ListBase
+    <ListBaseWithOnlyPublishedResources
       perPage={views[initialView].perPage}
       filterDefaultValues={views[initialView].filterDefaultValues}
       sort={views[initialView].sort}
       {...rest}
     >
       <MultiViewsFilterListView views={views} filters={filters} currentView={currentView} setView={setView} clearFilters={clearFilters}/>
-    </ListBase>
+    </ListBaseWithOnlyPublishedResources>
   )
 };
 

--- a/frontoffice/src/commons/lists/TabbedList/TabbedList.js
+++ b/frontoffice/src/commons/lists/TabbedList/TabbedList.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { ListBase } from 'react-admin';
 import TabbedListView from "./TabbedListView";
 import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 

--- a/frontoffice/src/commons/lists/TabbedList/TabbedList.js
+++ b/frontoffice/src/commons/lists/TabbedList/TabbedList.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { ListBase } from 'react-admin';
 import TabbedListView from "./TabbedListView";
+import ListBaseWithOnlyPublishedResources from '../ListBaseWithOnlyPublishedResources';
 
 const TabbedList = ({ tabs, filters, futureActivities, ...rest }) => {
   return(
-    <ListBase perPage={1000} {...rest}>
+    <ListBaseWithOnlyPublishedResources perPage={1000} {...rest}>
       <TabbedListView tabs={tabs} filters={filters} futureActivities={futureActivities}/>
-    </ListBase>
+    </ListBaseWithOnlyPublishedResources>
   )
 };
 

--- a/frontoffice/src/commons/lists/TabbedList/TabbedListView.js
+++ b/frontoffice/src/commons/lists/TabbedList/TabbedListView.js
@@ -110,23 +110,20 @@ const TabbedListView = ({ tabs, filters, futureActivities }) => {
       }
       if (dataByTabs['Place']) {
         dataByTabs['Place']=Object.fromEntries(Object.entries(dataByTabs['Place'])
-          .filter(key => key[1]['id'].includes(process.env.REACT_APP_MIDDLEWARE_URL))
-          .filter(key => key[1]['cdlt:hasPublicationStatus']===process.env.REACT_APP_MIDDLEWARE_URL+"publication-status/valide"))
+          .filter(key => key[1]['id'].includes(process.env.REACT_APP_MIDDLEWARE_URL)))
       }
       if (dataByTabs['Course']) {
-        dataByTabs['Course']=Object.fromEntries(Object.entries(dataByTabs['Course']).filter(key => key[1]['cdlt:hasPublicationStatus']===process.env.REACT_APP_MIDDLEWARE_URL+"publication-status/valide"))
         if (futureActivities) {
-          dataByTabs['Course']=Object.fromEntries(Object.entries(dataByTabs['Course']).filter(key => key[1]['pair:startDate']>(new Date()).toISOString()))
+          dataByTabs['Course']=Object.fromEntries(Object.entries(dataByTabs['Course'])
+            .filter(key => key[1]['pair:startDate']>(new Date()).toISOString()))
         }
       }
       if (futureActivities && dataByTabs['Event']) {
         dataByTabs['Event']=Object.fromEntries(Object.entries(dataByTabs['Event'])
-          .filter(key => key[1]['pair:startDate']>(new Date()).toISOString())
-          .filter(key => key[1]['cdlt:hasPublicationStatus']===process.env.REACT_APP_MIDDLEWARE_URL+"publication-status/valide"))
+          .filter(key => key[1]['pair:startDate']>(new Date()).toISOString()))
       }
       if (dataByTabs['Organization']) {
-        dataByTabs['Organization']=Object.fromEntries(Object.entries(dataByTabs['Organization'])
-          .filter(key => key[1]['cdlt:hasPublicationStatus']===process.env.REACT_APP_MIDDLEWARE_URL+"publication-status/valide"))
+        dataByTabs['Organization']=Object.fromEntries(Object.entries(dataByTabs['Organization']))
       }
       return dataByTabs;
     }

--- a/frontoffice/src/config/constants.js
+++ b/frontoffice/src/config/constants.js
@@ -1,0 +1,2 @@
+export const PUBLISHED_STATUS = process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide';
+export const UNPUBLISHED_STATUS = process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/en-cours';

--- a/frontoffice/src/resources/Agent/Activity/Course/CourseShow.js
+++ b/frontoffice/src/resources/Agent/Activity/Course/CourseShow.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, UrlField, Link, linkToRecord , useTranslate} from 'react-admin';
+import { ChipField, SingleFieldList, TextField, UrlField, Link, linkToRecord, useTranslate} from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider } from '@material-ui/core';
 import resourceTheme from '../../../../config/themes/resourceTheme';
 import resourceShowStyle from '../../../../commons/style/resourceShowStyle';
@@ -34,7 +35,7 @@ const CourseShow = (props) => {
   const translate = useTranslate();
   return (
     <ThemeProvider theme={resourceTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             details={<CourseDetails />}
@@ -173,7 +174,7 @@ const CourseShow = (props) => {
           <br />
           <ContactDialog open={showDialog} onClose={() => setShowDialog(false)} />
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };

--- a/frontoffice/src/resources/Agent/Activity/Event/EventList.js
+++ b/frontoffice/src/resources/Agent/Activity/Event/EventList.js
@@ -24,7 +24,6 @@ const EventList = (props) => {
 
   return (
     <MultiViewsFilterList
-      filter= {{ 'cdlt:hasPublicationStatus': process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide' }}
       filters={[
         <SearchFilter />,
         <SparqlFilter checked={checked} setChecked={setChecked} sparqlWhere={futureEventSparql} label={translate('app.card.event.onlyFutureEvents')} />,

--- a/frontoffice/src/resources/Agent/Activity/Event/EventShow.js
+++ b/frontoffice/src/resources/Agent/Activity/Event/EventShow.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, useTranslate } from 'react-admin';
+import { ChipField, SingleFieldList, TextField, useTranslate } from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider } from '@material-ui/core';
 import resourceTheme from '../../../../config/themes/resourceTheme';
 import resourceShowStyle from '../../../../commons/style/resourceShowStyle';
@@ -30,7 +31,7 @@ const EventShow = (props) => {
   const translate = useTranslate();
   return (
     <ThemeProvider theme={resourceTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             details={<EventDetails />}
@@ -153,7 +154,7 @@ const EventShow = (props) => {
           <br />
           <ContactDialog open={showDialog} onClose={() => setShowDialog(false)} />
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };

--- a/frontoffice/src/resources/Agent/Actor/Organization/OrganizationShow.js
+++ b/frontoffice/src/resources/Agent/Actor/Organization/OrganizationShow.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, useTranslate } from 'react-admin';
+import { ChipField, SingleFieldList, TextField, useTranslate } from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider, FormControlLabel, Checkbox, FormGroup } from '@material-ui/core';
 import organizationTheme from '../../../../config/themes/organizationTheme';
 import resourceShowStyle from '../../../../commons/style/resourceShowStyle';
@@ -33,7 +34,7 @@ const OrganizationShow = (props) => {
 
   return (
     <ThemeProvider theme={organizationTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             type="pair:hasType"
@@ -164,7 +165,7 @@ const OrganizationShow = (props) => {
           </BodyList>
           <ContactDialog open={showDialog} onClose={() => setShowDialog(false)} />
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };

--- a/frontoffice/src/resources/Idea/Path/PathList.js
+++ b/frontoffice/src/resources/Idea/Path/PathList.js
@@ -1,18 +1,21 @@
 import React from 'react';
-import { ListBase } from 'react-admin';
+import ListBaseWithOnlyPublishedResources from '../../../commons/lists/ListBaseWithOnlyPublishedResources';
 import { Box, Container } from '@material-ui/core';
 import CardsList from '../../../commons/lists/CardsList';
 import PathCard from './PathCard';
 
 const PathList = (props) => {
   return (
-    <ListBase perPage={1000} {...props}>
+    <ListBaseWithOnlyPublishedResources 
+      perPage={1000} 
+      {...props}
+    >
       <Container>
         <Box sx={{ m: 4 }}>
           <CardsList CardComponent={PathCard} />
         </Box>
       </Container>
-    </ListBase>
+    </ListBaseWithOnlyPublishedResources>
   );
 }
 

--- a/frontoffice/src/resources/Idea/Path/PathShow.js
+++ b/frontoffice/src/resources/Idea/Path/PathShow.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, useTranslate} from 'react-admin';
+import { ChipField, SingleFieldList, TextField, useTranslate} from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider } from '@material-ui/core';
 import resourceTheme from '../../../config/themes/resourceTheme';
 import resourceShowStyle from '../../../commons/style/resourceShowStyle';
@@ -33,7 +34,7 @@ const PathShow = (props) => {
 
   return (
     <ThemeProvider theme={resourceTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             type="pair:hasType"
@@ -121,7 +122,7 @@ const PathShow = (props) => {
           <br />
           <ContactDialog open={showDialog} onClose={() => setShowDialog(false)} />
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };

--- a/frontoffice/src/resources/OfferAndNeed/OfferAndNeedList.js
+++ b/frontoffice/src/resources/OfferAndNeed/OfferAndNeedList.js
@@ -15,7 +15,6 @@ const OfferAndNeedList = (props) => {
   const translate = useTranslate();
   return (
     <MultiViewsFilterList
-      filter= {{ 'cdlt:hasPublicationStatus': process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide' }}
       filters={[
         <SearchFilter />,
         <Filter

--- a/frontoffice/src/resources/OfferAndNeed/OfferAndNeedShow.js
+++ b/frontoffice/src/resources/OfferAndNeed/OfferAndNeedShow.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, UrlField, useTranslate } from 'react-admin';
+import { ChipField, SingleFieldList, TextField, UrlField, useTranslate } from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider, Box } from '@material-ui/core';
 import resourceTheme from '../../config/themes/resourceTheme';
 import resourceShowStyle from '../../commons/style/resourceShowStyle';
@@ -22,7 +23,7 @@ const OfferAndNeedShow = (props) => {
   const translate = useTranslate();
   return (
     <ThemeProvider theme={resourceTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             type="pair:hasType"
@@ -74,7 +75,7 @@ const OfferAndNeedShow = (props) => {
             <UrlField source="pair:homePage" className={classes.urlField} />
           </BodyList>
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };

--- a/frontoffice/src/resources/Place/PlaceList.js
+++ b/frontoffice/src/resources/Place/PlaceList.js
@@ -15,7 +15,6 @@ const PlaceList = (props) => {
   const translate = useTranslate();
   return (
     <MultiViewsFilterList
-      filter= {{ 'cdlt:hasPublicationStatus': process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide' }}
       filters={[
         <SearchFilter />,
         <Filter reference="Region" source="cdlt:hasRegion" inverseSource="cdlt:regionOf" label={translate('app.input.region')} />,

--- a/frontoffice/src/resources/Place/PlaceShow.js
+++ b/frontoffice/src/resources/Place/PlaceShow.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { ChipField, ShowBase, SingleFieldList, TextField, UrlField, useTranslate } from 'react-admin';
+import { ChipField, SingleFieldList, TextField, UrlField, useTranslate } from 'react-admin';
+import ShowBaseOnlyIfPublished from '../../commons/ShowBaseOnlyIfPublished';
 import { ThemeProvider, Checkbox, FormGroup, FormControlLabel, Box, Typography } from '@material-ui/core';
 import resourceTheme from '../../config/themes/resourceTheme';
 import resourceShowStyle from '../../commons/style/resourceShowStyle';
@@ -34,7 +35,7 @@ const PlaceShow = (props) => {
   const classes = useStyles();
   return (
     <ThemeProvider theme={resourceTheme}>
-      <ShowBase {...props}>
+      <ShowBaseOnlyIfPublished {...props}>
         <Box className={classes.mainContainer}>
           <HeaderShow
             type="pair:hasType"
@@ -148,7 +149,7 @@ const PlaceShow = (props) => {
           <br />
           <ContactDialog open={showDialog} onClose={() => setShowDialog(false)} />
         </Box>
-      </ShowBase>
+      </ShowBaseOnlyIfPublished>
     </ThemeProvider>
   );
 };


### PR DESCRIPTION
**Application des filtres "statut publié" dans tous les composants :**  
- J'ai créé des constantes pour les statuts de publication sur le backoffice et le frontoffice mais je n'ai pas remplacé toutes les utilisations existantes en dur (ex : `process.env.REACT_APP_MIDDLEWARE_URL + 'publication-status/valide'`).
- J'ai pu supprimer des contrôles de statut, devenus inutiles en effectuant ce contrôle plus en amont (avec `ListBaseWithOnlyPublishedResources` par exemple).

**Redirection  des tentatives de consultation de ressources non publiées:**
- cf composant `ShowBaseOnlyIfPublished`